### PR TITLE
Update sprint dates on the ticket page

### DIFF
--- a/djangocon_2022/content/tickets/tickets.md
+++ b/djangocon_2022/content/tickets/tickets.md
@@ -1,7 +1,7 @@
 title: tickets
 layout: simple
 
-**All tickets include access to all 3 conference days (September 21 - 23) and the 2 sprints days (June 24 - 25)**. Don't forget to follow us on Twitter [@DjangoConEurope](https://twitter.com/djangoconeurope){:target="_blank"} for the latest up to date information!
+**All tickets include access to all 3 conference days (September 21 - 23) and the 2 sprints days (September 24 - 25)**. Don't forget to follow us on Twitter [@DjangoConEurope](https://twitter.com/djangoconeurope){:target="_blank"} for the latest up to date information!
 
 [<center><button class="btn">Grab your ticket!</button></center>](https://pretix.evolutio.pt/evolutio/djceu2022/){:target="_blank"}
 


### PR DESCRIPTION
On [announcements page](https://2022.djangocon.eu/information/announcements/) sprint have September dates, but ticket page still lists June dates (I assume those are dates from last year).