### PR TITLE
Add CoC transparency report

### DIFF
--- a/djangocon_2022/content/conduct/code_of_conduct/code_of_conduct.md
+++ b/djangocon_2022/content/conduct/code_of_conduct/code_of_conduct.md
@@ -11,6 +11,7 @@ The team can be reached on [conduct@djangocon.eu](mailto:conduct@djangocon.eu) a
 * Mustapha Unubi Momoh
 * Noah Alorwu
 * Nuno Hespanhol
+* Thibaud Colas
 
 We would like to thank the DjangoCon Europe 2019 CoC team for the awesome CoC (which we adapted with some minor modifications) and the response guidelines (which we have adopted almost unedited from 2018).
 

--- a/djangocon_2022/content/information/announcements/9997-20221116.md
+++ b/djangocon_2022/content/information/announcements/9997-20221116.md
@@ -1,0 +1,79 @@
+title: 17 November<br/>2022
+layout: simple
+class: bg-white
+
+### Code of Conduct transparency report
+
+This year, the [DjangoCon Europe 2022 Code of Conduct Active Response Team](https://2022.djangocon.eu/conduct/code_of_conduct/){:target="_blank"} (CARE) had a very uneventful conference. We are nonetheless publishing a full Code of Conduct transparency report.
+
+Publishing this report is a part of our [Code of Conduct process](https://2022.djangocon.eu/conduct/response_guide/){:target="_blank"}, which informs our work before, during, and after the conference. The report itself provides information about general team tasks, as well as incidents we handled.
+
+##### The code of conduct and our team
+
+The DjangoCon Europe [Code of Conduct](https://2022.djangocon.eu/conduct/code_of_conduct/){:target="_blank"} (CoC) and the workings of the CARE team are directly taken from past events. For this year, the team was set up by the event organisers and staffed with five volunteers:
+
+- Eve Cardoso
+- Mustapha Unubi Momoh
+- Noah Alorwu
+- Nuno Hespanhol
+- Thibaud Colas
+
+Our group handled everything CoC-related for the conference, with support from the organisers where needed, in particular Miguel Magalhães. All CoC reports are handled solely by the team, with an important policy that all decisions are made as a group whenever possible. Thibaud was available in person at the conference, while other team members were in attendance online.
+
+It’s worth mentioning the team is fully separate from the [Django Software Foundation’s Code of Conduct Committee](https://www.djangoproject.com/foundation/committees/#conduct){:target="_blank"}, which handles violations with [Django’s Code of Conduct](https://www.djangoproject.com/conduct/){:target="_blank"}. This separate code of conduct also applies to all DSF events, including DjangoCon Europe.
+
+#### Before the conference
+
+Our team had two major tasks before the conference.
+
+##### Preparing for the event
+
+This generally meant doing anything we could ahead of the actual conference so our team could work as well as possible during the event.
+
+- Getting up to speed with general Code of Conduct team practices.
+- And learning and refining those of the CARE team in particular.
+- Making sure we are familiar with moderation features across the different online platforms.
+- Confirming availability so we know we will have some presence throughout the whole conference, in person as well as online (Slack).
+
+##### Reviewing talks from speakers
+
+All speakers were required to submit a draft version of their slides, ideally in the week before the conference, as far complete as possible. The CARE team went through the slides much later than ideal, with only 20 out of 45 talks reviewed in time. This was largely because our team started this process too late, with the additional problem that a majority of speakers hadn’t provided their slides when prompted or had done so without ensuring the slides were publicly-accessible.
+
+Due to the rushed turnaround, the majority of reviewed talks were only checked by one CARE team member, which is also not ideal. We didn’t review lightning talks, as they were scheduled on the day of the event, often on very short notice, without the CARE team being involved in the process.
+
+Of the 21 presentations we attempted to review,
+
+- 20 were reviewed without comments.
+- 1 wasn’t submitted on time by the speaker despite reminders.
+
+In addition, two speakers reached out to clarify the application of the code of conduct to specific aspects of their talks. We advised in both cases.
+
+#### During the conference
+
+Plain and simple, there were no incidents reported during the conference! Everyone involved played a part in fostering an excellent atmosphere throughout – with good Q&As after talks, and attendees supporting one-another in person and on Slack. The conference code of conduct was featured prominently, which helped set clear expectations for everyone.
+
+##### Sprints
+
+Our team also had a small representation during the sprints on Saturday and Sunday. This all went very well!
+
+#### After the conference
+
+With the conference over, with no incidents reported during the event, our team’s remit was to:
+
+- Keep an eye out for any report sent to us after the conference.
+- Drafting a report to Django’s own Code of Conduct Committee [records](https://github.com/django/code-of-conduct/blob/main/records.md#record-keeping){:target="_blank"}.
+- Writing this transparency report.
+
+#### About this report
+
+Even without any incidents to report on, we still believe publishing this report is a good way to show why our CoC is important, and how it is enforced in practice, in line with the [transparency guidelines](https://github.com/django/code-of-conduct/blob/main/transparency.md){:target="_blank"} from Django’s CoC committee. We hope that by publishing this, we will encourage people to report incidents in the future, and that other conferences can learn from our mistakes and our successes.
+We welcome any feedback, and we would like to thank the DjangoCon Europe community – attendees, speakers, and organisers alike – for working with us.
+We thank the organisers of DjangoCon Europe 2021 for their transparency report, which we followed as a template for this year’s report.
+
+The DjangoCon Europe 2022 Code of Conduct Active Response Ensurers team,
+
+- Eve Cardoso
+- Mustapha Unubi Momoh
+- Noah Alorwu
+- Nuno Hespanhol
+- Thibaud Colas


### PR DESCRIPTION
A bit late, but better late than never. This follows [last year’s transparency report](https://github.com/djangocon/2021.djangocon.eu/commit/5a57cc9302a55ec4573fce56663b69a8392b0de9) (also largely authored by me), with much less to cover. I still found it useful for us to share our process around talks reviews, and the fact we had a presence before, during, and after the event.